### PR TITLE
Cluster timestamped comments for timeline

### DIFF
--- a/extension/styles.css
+++ b/extension/styles.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  height: 6px;
+  height: 14px;
   background: rgba(255,255,255,0.15);
   z-index: 1000;
   pointer-events: auto;
@@ -13,11 +13,17 @@
 .yt-moments-overlay .marker {
   position: absolute;
   top: 0;
-  width: 6px;
+  width: 14px;
   height: 100%;
   transform: translateX(-50%);
-  border-radius: 2px;
+  border-radius: 6px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: #fff;
+  text-shadow: 0 0 4px rgba(0,0,0,0.6);
 }
 
 .yt-moments-overlay .marker[data-emotion="funny"] { background: #fbc02d; }
@@ -55,6 +61,53 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+.sp-item .cluster-meta {
+  margin-top: 4px;
+  color: #555;
+  font-size: 12px;
+}
+.sp-item .comment-author {
+  margin-top: 2px;
+  color: #777;
+  font-size: 12px;
+}
+.sp-item .comment-snippet {
+  margin-top: 4px;
+  color: #333;
+  white-space: pre-wrap;
+}
+.sp-item .sample-comments {
+  margin-top: 6px;
+  padding-left: 16px;
+  color: #555;
+  font-size: 12px;
+}
+.sp-item .sample-comments li {
+  margin-bottom: 2px;
+}
+.sp-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.sp-actions .reason {
+  color: #666;
+  flex: 1 1 auto;
+}
+.retry-button {
+  margin: 4px 0 8px;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #f5f5f5;
+  font-size: 12px;
+  cursor: pointer;
+}
+.retry-button:hover {
+  background: #e9e9e9;
 }
 .dot {
   width: 10px;


### PR DESCRIPTION
## Summary
- build clusters from timestamped comments instead of transcript windows and score them for the timeline
- classify each cluster's emotion, cache the results, and render emoji markers over the player
- refresh the side panel to highlight cluster details, sample comments, and provide a retry control

